### PR TITLE
docs: mention posts and project directories in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bavalpreet.github.io — Fresh Start
 
-This is a fully-filled GitHub Pages (Jekyll) portfolio. Edit only `_data/profile.yml` to update content site‑wide.
+This is a fully-filled GitHub Pages (Jekyll) portfolio. Edit `_data/profile.yml` for profile content; add or modify entries under `_posts/` and `_projects/` for posts and project pages.
 
 ## Publish
 1) Create a public repo named **bavalpreet.github.io**.


### PR DESCRIPTION
## Summary
- clarify that posts and project content lives in `_posts/` and `_projects/`

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68a788099a8c8320aaa0827a34794ce4