### PR TITLE
Revamp styling and surface Medium posts

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ page.title }} — {{ site.title }}</title>
     <meta name="description" content="{{ site.description }}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
   </head>
   <body>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,19 +1,126 @@
-:root { --bg:#0b0f14; --card:#111827; --text:#e5e7eb; --muted:#9ca3af; --accent:#60a5fa; }
-*{box-sizing:border-box}
-body{margin:0;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,'Helvetica Neue',Arial;color:var(--text);background:linear-gradient(180deg,#0b0f14,#0a0f1a)}
-a{color:var(--accent);text-decoration:none}
-.container{max-width:1000px;margin:40px auto;padding:0 20px}
-.site-header,.site-footer{display:flex;justify-content:space-between;align-items:center;padding:16px 20px;background:#0b1220cc;backdrop-filter:blur(8px);position:sticky;top:0}
-.brand{font-weight:700;font-size:18px}
-nav a{margin-left:16px}
-.card{background:var(--card);border:1px solid #1f2937;border-radius:16px;padding:20px;margin:14px 0;box-shadow:0 10px 30px rgba(0,0,0,.25)}
-.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:16px}
-.h1{font-size:34px;margin:0 0 8px 0}
-.h2{font-size:22px;margin:18px 0 8px}
-.mono{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace}
-.badge{display:inline-block;border:1px solid #374151;border-radius:999px;padding:4px 10px;margin:4px 6px 0 0;font-size:12px;color:var(--muted)}
-.hero{display:grid;grid-template-columns:1.1fr .9fr;gap:18px;align-items:center}
-@media (max-width:880px){.hero{grid-template-columns:1fr}}
-.hr{height:1px;background:#1f2937;margin:24px 0}
-ul{margin:0 0 0 18px}
-kbd{background:#0e1726;border:1px solid #263245;border-radius:6px;padding:2px 6px}
+:root {
+  --bg: #f9fafb;
+  --card: #ffffff;
+  --text: #1f2937;
+  --muted: #6b7280;
+  --accent: #3b82f6;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, 'Helvetica Neue', Arial, sans-serif;
+  color: var(--text);
+  background: var(--bg);
+  line-height: 1.6;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.container {
+  max-width: 960px;
+  margin: 40px auto;
+  padding: 0 20px;
+}
+
+.site-header,
+.site-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px;
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(8px);
+  position: sticky;
+  top: 0;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.brand {
+  font-weight: 700;
+  font-size: 18px;
+  color: var(--text);
+}
+
+nav a {
+  margin-left: 16px;
+  color: var(--text);
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  padding: 20px;
+  margin: 14px 0;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+.h1 {
+  font-size: 34px;
+  margin: 0 0 8px 0;
+}
+
+.h2 {
+  font-size: 22px;
+  margin: 18px 0 8px;
+}
+
+.mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+}
+
+.badge {
+  display: inline-block;
+  border: 1px solid #d1d5db;
+  border-radius: 999px;
+  padding: 4px 10px;
+  margin: 4px 6px 0 0;
+  font-size: 12px;
+  color: var(--muted);
+  background: #f3f4f6;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 18px;
+  align-items: center;
+}
+
+@media (max-width: 880px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+}
+
+.hr {
+  height: 1px;
+  background: #e5e7eb;
+  margin: 24px 0;
+}
+
+ul {
+  margin: 0 0 0 18px;
+  padding: 0;
+}
+
+kbd {
+  background: #f3f4f6;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  padding: 2px 6px;
+}
+

--- a/posts.html
+++ b/posts.html
@@ -12,3 +12,20 @@ title: Posts
     </li>
   {% endfor %}
 </ul>
+
+<h2 class="h2">Medium Posts</h2>
+<ul id="medium-posts"></ul>
+<script>
+fetch('https://api.rss2json.com/v1/api.json?rss_url=https://medium.com/feed/@bavalpreet')
+  .then(r => r.json())
+  .then(data => {
+    const posts = data.items.filter(item => item.categories.length > 0).slice(0,5);
+    const container = document.getElementById('medium-posts');
+    posts.forEach(post => {
+      const li = document.createElement('li');
+      const date = new Date(post.pubDate).toLocaleDateString(undefined,{year:'numeric',month:'short',day:'numeric'});
+      li.innerHTML = `<a href="${post.link}" target="_blank">${post.title}</a> <span class="badge">${date}</span>`;
+      container.appendChild(li);
+    });
+  });
+</script>


### PR DESCRIPTION
## Summary
- Refresh site layout with a light theme, Inter font and subtle card styling
- Add Google Fonts to base layout
- Display latest Medium articles alongside local posts via RSS feed

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a78b8afee08320a449f2e4b5a0cb35