### PR TITLE
Add Medium blog post links

### DIFF
--- a/posts.html
+++ b/posts.html
@@ -14,18 +14,18 @@ title: Posts
 </ul>
 
 <h2 class="h2">Medium Posts</h2>
-<ul id="medium-posts"></ul>
-<script>
-fetch('https://api.rss2json.com/v1/api.json?rss_url=https://medium.com/feed/@bavalpreet')
-  .then(r => r.json())
-  .then(data => {
-    const posts = data.items.filter(item => item.categories.length > 0).slice(0,5);
-    const container = document.getElementById('medium-posts');
-    posts.forEach(post => {
-      const li = document.createElement('li');
-      const date = new Date(post.pubDate).toLocaleDateString(undefined,{year:'numeric',month:'short',day:'numeric'});
-      li.innerHTML = `<a href="${post.link}" target="_blank">${post.title}</a> <span class="badge">${date}</span>`;
-      container.appendChild(li);
-    });
-  });
-</script>
+<ul>
+  <li>
+    <a href="https://medium.com/stackademic/pydantic-in-production-avoiding-performance-pitfalls-b204d5949c6e" target="_blank">
+      Pydantic in Production: Avoiding Performance Pitfalls
+    </a>
+  </li>
+  <li>
+    <a href="https://medium.com/ai-advances/graph-based-re-ranking-enhancing-retrieval-with-graph-neural-networks-6d4b5d4ddc3a" target="_blank">
+      Graph-Based Re-Ranking: Enhancing Retrieval with Graph Neural Networks
+    </a>
+  </li>
+</ul>
+<p>
+  <a href="https://medium.com/search?q=bavalpreetsinghh" target="_blank">More on Medium →</a>
+</p>


### PR DESCRIPTION
## Summary
- Include two Medium articles and link to full story list on the posts page.

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a78f5f4ee88320834ffc7b427611cf