### PR TITLE
Add recommendations page and navigation

### DIFF
--- a/_data/recommendations.yml
+++ b/_data/recommendations.yml
@@ -1,0 +1,5 @@
+- author: Jane Doe
+  role: Senior Colleague
+  date: Jan 2025
+  text: >-
+    Bavalpreet's expertise and dedication made a significant impact on our project.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,6 +18,7 @@
         <a href="{{ '/experience/' | relative_url }}">Experience</a>
         <a href="{{ '/projects/' | relative_url }}">Projects</a>
         <a href="{{ '/publications/' | relative_url }}">Publications</a>
+        <a href="{{ '/recommendations/' | relative_url }}">Recommendations</a>
         <a href="{{ '/posts.html' | relative_url }}">Posts</a>
       </nav>
     </header>

--- a/recommendations.md
+++ b/recommendations.md
@@ -1,0 +1,18 @@
+---
+layout: default
+title: Recommendations
+permalink: /recommendations/
+---
+
+<h1 class="h1">Recommendations</h1>
+<div class="hr"></div>
+
+{% for rec in site.data.recommendations %}
+<div class="card">
+  <p><strong>{{ rec.author }}</strong> — {{ rec.role }}</p>
+  <p class="mono">{{ rec.date }}</p>
+  <p>{{ rec.text }}</p>
+</div>
+{% endfor %}
+
+<p><a href="https://www.linkedin.com/in/bavalpreet-singh/details/recommendations/">See more on LinkedIn</a></p>


### PR DESCRIPTION
## Summary
- add Recommendations page that renders entries from `_data/recommendations.yml`
- include new Recommendations link in the site navigation

## Testing
- `gem install jekyll --no-document` *(fails: client error (Connect): tunnel error: unsuccessful)*
- `jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a7919b2edc8320ad12edc647d60c7c