### PR TITLE
Update profile bio with agentic AI focus

### DIFF
--- a/_data/profile.yml
+++ b/_data/profile.yml
@@ -1,13 +1,17 @@
 name: Bavalpreet Singh
-headline: Data Scientist & AI/ML Engineer | Conversational AI, GenAI, NLP
+headline: AI Professional | Agentic AI Innovator | Top 0.1% Data & ML Strategist
 location: Toronto, Ontario, Canada
 email: scientist.bavalpreet@gmail.com
 linkedin: https://www.linkedin.com/in/bavalpreet-singh
 github: https://github.com/Bavalpreet
-about: AI professional focused on solving real problems with Machine Learning and
-  Generative AI. Led impactful projects including AI chatbots for US local governments
-  (43% staffing cost reduction, 39% profit increase). Passionate mentor and educator;
-  published in Conversational AI and NER.
+about: |
+  Bavalpreet Singh is an AI professional at the intersection of Machine Learning, Generative AI, and agentic systems—designing intelligent solutions that actively reason, adapt, and collaborate. He has led transformative projects, including next-generation AI chatbots deployed across U.S. local governments, delivering a 43% reduction in staffing costs and a 39% boost in profits.
+
+  Bavalpreet’s passion for mentorship and education is matched by his drive for innovation. He has published research in Conversational AI and Named Entity Recognition, and continues to explore agentic AI paradigms that enable autonomous, goal-driven machines to solve complex real-world problems. As a prolific mentor, he has shaped the careers of rising AI talent while refining his own craft.
+
+  Guided by a mindset common among the top 0.1% of data scientists and AI/ML engineers, Bavalpreet is obsessed with measurable impact, rigorous experimentation, and continuous learning. From architecting agent-based model ecosystems to crafting scalable data pipelines, he thrives on tackling problems end-to-end.
+
+  Bavalpreet’s mission: build AI systems that don’t just predict or respond, but proactively act—collaborating with humans to drive intelligent outcomes. Connect with him to explore the frontier of agentic AI and push beyond what’s possible.
 highlights:
 - "Delivered AI chatbots for US local governments \u2192 43% staffing cost reduction\
   \ & 39% profit increase."


### PR DESCRIPTION
## Summary
- refresh headline to highlight agentic AI expertise and strategic focus
- expand about section with a detailed agentic AI biography

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a792a5e3048320b891a29b1d9ac179