### PR TITLE
Showcase LinkedIn testimonials on home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@ Your site will appear at https://bavalpreet.github.io
 - Home/Experience/Projects pull from `_data/profile.yml` and `_projects/`.
 - Add posts under `_posts/YYYY-MM-DD-title.md`.
 - Style is in `assets/css/style.css`.
+- Update LinkedIn recommendations by running `scripts/fetch_linkedin_recommendations.py`
+  with `LINKEDIN_ACCESS_TOKEN` and `LINKEDIN_PROFILE_ID` environment variables.

--- a/index.html
+++ b/index.html
@@ -47,6 +47,27 @@ title: Home
 </div>
 
 <div class="card">
+  <h2 class="h2">Publications</h2>
+  <ul>
+  {% for pub in p.publications limit:3 %}
+    <li><a href="{{ pub.link }}">{{ pub.title }}</a></li>
+  {% endfor %}
+  </ul>
+  <p><a href="{{ '/publications/' | relative_url }}">More publications →</a></p>
+</div>
+
+<div class="card">
+  <h2 class="h2">Recommendations</h2>
+  {% for rec in site.data.recommendations limit:3 %}
+    <p><strong>{{ rec.author }}</strong> — {{ rec.role }}</p>
+    <p class="mono">{{ rec.date }}</p>
+    <p>{{ rec.text }}</p>
+    {% if forloop.last == false %}<div class="hr"></div>{% endif %}
+  {% endfor %}
+  <p><a href="{{ '/recommendations/' | relative_url }}">See all →</a></p>
+</div>
+
+<div class="card">
   <h2 class="h2">Latest Posts</h2>
   <ul>
   {% for post in site.posts limit:4 %}

--- a/scripts/fetch_linkedin_recommendations.py
+++ b/scripts/fetch_linkedin_recommendations.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Fetch LinkedIn recommendations and update Jekyll data file.
+
+The script calls the LinkedIn API to retrieve recommendations for the
+configured profile and writes them to `_data/recommendations.yml` in the
+format expected by the site. Set the following environment variables before
+running:
+
+- `LINKEDIN_ACCESS_TOKEN`: OAuth access token with permission to read
+  recommendations.
+- `LINKEDIN_PROFILE_ID`: The numeric ID of the LinkedIn profile.
+
+Example usage:
+    $ LINKEDIN_ACCESS_TOKEN=xxx LINKEDIN_PROFILE_ID=123 \
+        python scripts/fetch_linkedin_recommendations.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+from typing import List, Dict
+
+import requests
+import yaml
+
+API_URL = "https://api.linkedin.com/v2/recommendations"
+
+
+def fetch_recommendations(token: str, profile_id: str) -> List[Dict[str, str]]:
+    """Return recommendations for the given profile from LinkedIn."""
+    headers = {"Authorization": f"Bearer {token}"}
+    params = {"q": "recipient", "profileId": profile_id}
+    response = requests.get(API_URL, headers=headers, params=params, timeout=10)
+    response.raise_for_status()
+    elements = response.json().get("elements", [])
+    recs: List[Dict[str, str]] = []
+    for item in elements:
+        recommender = item.get("recommender", {})
+        recs.append(
+            {
+                "author": recommender.get("name", ""),
+                "role": recommender.get("headline", ""),
+                "date": item.get("createdAt", ""),
+                "text": item.get("recommendationText", ""),
+            }
+        )
+    return recs
+
+
+def save_recommendations(recommendations: List[Dict[str, str]]) -> None:
+    """Write recommendations to `_data/recommendations.yml`."""
+    data_path = os.path.join(os.path.dirname(__file__), "..", "_data", "recommendations.yml")
+    with open(data_path, "w", encoding="utf-8") as fh:
+        yaml.dump(recommendations, fh, allow_unicode=True, sort_keys=False)
+
+
+if __name__ == "__main__":
+    token = os.getenv("LINKEDIN_ACCESS_TOKEN")
+    profile_id = os.getenv("LINKEDIN_PROFILE_ID")
+    if not token or not profile_id:
+        sys.exit("Set LINKEDIN_ACCESS_TOKEN and LINKEDIN_PROFILE_ID environment variables.")
+    recs = fetch_recommendations(token, profile_id)
+    save_recommendations(recs)
+    print(f"Saved {len(recs)} recommendations.")


### PR DESCRIPTION
## Summary
- Add a Python utility to fetch LinkedIn recommendations into the site data file.
- Highlight publications and LinkedIn recommendations on the home page.
- Document how to update recommendations using the new script.

## Testing
- `python scripts/fetch_linkedin_recommendations.py` *(fails: Set LINKEDIN_ACCESS_TOKEN and LINKEDIN_PROFILE_ID environment variables.)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c3a5359883209ea10ffc97d2f91f