### PR TITLE
Add projects page and hover style

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Your site will appear at https://bavalpreet.github.io
 
 ## Customize
 - Home/Experience/Projects pull from `_data/profile.yml` and `_projects/`.
+- The Projects page (`/projects/`) showcases all data science and AI projects from `_projects/`.
 - Add posts under `_posts/YYYY-MM-DD-title.md`.
 - Style is in `assets/css/style.css`.
 - Update LinkedIn recommendations by running `scripts/fetch_linkedin_recommendations.py`

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -124,3 +124,10 @@ kbd {
   padding: 2px 6px;
 }
 
+
+.card:hover {
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.10);
+  transform: translateY(-2px);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+

--- a/projects/index.html
+++ b/projects/index.html
@@ -1,0 +1,21 @@
+---
+layout: default
+title: Projects
+---
+
+<section class="card">
+  <h1 class="h1">Projects</h1>
+  <p>A showcase of my data science and AI projects.</p>
+</section>
+
+<div class="grid">
+  {% for project in site.projects %}
+    <div class="card">
+      <h2 class="h2">{{ project.title }}</h2>
+      <p>{{ project.summary }}</p>
+      {% if project.tags %}<p class="mono">{{ project.tags | join: " · " }}</p>{% endif %}
+      {% if project.repo %}<p><a href="{{ project.repo }}" target="_blank">GitHub →</a></p>{% endif %}
+    </div>
+  {% endfor %}
+</div>
+


### PR DESCRIPTION
## Summary
- add dedicated Projects page listing data science work
- polish cards with hover effects
- document new projects page in README

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c8133e608320a9d79698564ab301