### PR TITLE
Add volunteer and mentorship section

### DIFF
--- a/_data/profile.yml
+++ b/_data/profile.yml
@@ -132,3 +132,16 @@ education:
 - school: Punjabi University
   program: B.Tech, Computer Science and Engineering
   date: "2016 \u2013 2020"
+volunteer:
+- company: Data Science for All
+  role: Mentor
+  date: "2022 \u2013 Present"
+  location: Remote
+  bullets:
+  - Support aspiring data scientists through project mentorship.
+- company: Local Community Hackathon
+  role: Volunteer
+  date: "2021 \u2013 2022"
+  location: Toronto, ON
+  bullets:
+  - Organized AI workshops for community participants.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,6 +19,7 @@
         <a href="{{ '/projects/' | relative_url }}">Projects</a>
         <a href="{{ '/publications/' | relative_url }}">Publications</a>
         <a href="{{ '/recommendations/' | relative_url }}">Recommendations</a>
+        <a href="{{ '/volunteer/' | relative_url }}">Volunteer</a>
         <a href="{{ '/posts.html' | relative_url }}">Posts</a>
       </nav>
     </header>

--- a/volunteer.md
+++ b/volunteer.md
@@ -1,0 +1,19 @@
+---
+layout: default
+title: Volunteer & Mentorship
+permalink: /volunteer/
+---
+{% assign p = site.data.profile %}
+
+<h1 class="h1">Volunteer & Mentorship</h1>
+<div class="hr"></div>
+
+{% for v in p.volunteer %}
+<div class="card">
+  <h3 class="h2">{{ v.role }} — {{ v.company }}</h3>
+  <p class="mono">{{ v.date }}{% if v.location %} · {{ v.location }}{% endif %}</p>
+  <ul>
+  {% for b in v.bullets %}<li>{{ b }}</li>{% endfor %}
+  </ul>
+</div>
+{% endfor %}


### PR DESCRIPTION
## Summary
- add dedicated Volunteer & Mentorship page
- surface volunteer page in site navigation
- populate profile data with volunteer experiences

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c9b5cc6c8320b197b7533fc0c131