### PR TITLE
Revamp home page with interactive tiles and status

### DIFF
--- a/_data/development.yml
+++ b/_data/development.yml
@@ -1,0 +1,4 @@
+gpu_status: "72°C"
+memory: "24.7 GB"
+activity: "1 commits"
+training: "87%"

--- a/_data/profile.yml
+++ b/_data/profile.yml
@@ -4,6 +4,7 @@ location: Toronto, Ontario, Canada
 email: scientist.bavalpreet@gmail.com
 linkedin: https://www.linkedin.com/in/bavalpreet-singh
 github: https://github.com/Bavalpreet
+kaggle: https://www.kaggle.com/bavalpreet26
 about: >
   Bavalpreet Singh is an AI professional specializing in generative AI, conversational AI, and agentic systems. He leads the development of intelligent, research-backed solutions in the financial and regulatory technology space—helping clients reduce manual effort, streamline workflows, and access trusted, citation-backed insights. Previously, he has delivered impactful AI projects for the public sector, published research in Conversational AI and NER, and mentored emerging talent. Recognized among the top engineers, his mission is to build AI systems that not only respond—but reason, adapt, and act alongside human experts.
 highlights:

--- a/_data/status.yml
+++ b/_data/status.yml
@@ -1,0 +1,4 @@
+impact_kusd: 700
+performance_gain_percent: 31
+engineers_mentored: 100
+location: Toronto, Canada

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -219,3 +219,55 @@ kbd {
   transition: box-shadow 0.2s ease, transform 0.2s ease;
 }
 
+.social-links a {
+  margin-right: 12px;
+}
+
+.stats {
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.stat {
+  text-align: center;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--badge-bg);
+}
+
+.stat h3 {
+  margin: 0;
+}
+
+.stat p {
+  margin: 4px 0 0;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.role-grid {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.role-tile {
+  display: flex;
+  align-items: center;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--badge-bg);
+}
+
+.role-tile .logo {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--card);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  margin-right: 12px;
+  border: 1px solid var(--border);
+}
+

--- a/index.html
+++ b/index.html
@@ -3,53 +3,117 @@ layout: default
 title: Home
 ---
 {% assign p = site.data.profile %}
+{% assign status = site.data.status %}
+{% assign env = site.data.development %}
 
 <section class="hero card">
   <div>
-    <h1 class="h1">Hi, I'm <span class="mono">{{ p.name }}</span> 👋</h1>
+    <h1 class="h1">{{ p.name }}</h1>
     <p>{{ p.headline }}</p>
-    <p class="mono">{{ p.location }}</p>
-    <div>
-      {% for s in p.skills limit:6 %}
-        <span class="badge">{{ s }}</span>
-      {% endfor %}
-    </div>
-    <div class="actions">
-      <a class="btn" href="{{ '/projects/' | relative_url }}">View Projects</a>
-    </div>
-  </div>
-  <div>
-    <div class="card">
-      <p>{{ p.about }}</p>
-      <p><strong>Contact:</strong>
-        <a href="mailto:{{ p.email }}">{{ p.email }}</a> ·
-        <a href="{{ p.linkedin }}" target="_blank">LinkedIn</a> ·
-        <a href="{{ p.github }}" target="_blank">GitHub</a></p>
+    <blockquote>"Working with LLMs is awesome but the real challenge comes when we ask 'How do we evaluate the output?'"</blockquote>
+    <div class="actions social-links">
+      <a href="{{ p.linkedin }}" target="_blank">LinkedIn</a>
+      <a href="{{ p.github }}" target="_blank">GitHub</a>
+      <a href="{{ p.kaggle }}" target="_blank">Kaggle</a>
+      <a href="/resume.pdf" target="_blank">Resume</a>
     </div>
   </div>
 </section>
 
-  <div class="card">
-    <h2 class="h2">Highlights</h2>
-    <ul>
-      {% for h in p.highlights %}
-        <li>{{ h }}</li>
-      {% endfor %}
-    </ul>
+<section class="card">
+  <h2 class="h2">Current Status</h2>
+  <div class="grid stats">
+    <div class="stat">
+      <h3 class="h1">{{ status.impact_kusd }}</h3>
+      <p class="mono">K USD Impact</p>
+    </div>
+    <div class="stat">
+      <h3 class="h1">{{ status.performance_gain_percent }}%</h3>
+      <p class="mono">% Performance Gains</p>
+    </div>
+    <div class="stat">
+      <h3 class="h1">{{ status.engineers_mentored }}</h3>
+      <p class="mono">Engineers Mentored</p>
+    </div>
+    <div class="stat">
+      <h3 class="h1">{{ status.location }}</h3>
+      <p class="mono">Location</p>
+    </div>
   </div>
+</section>
 
-  <div class="card">
-    <h2 class="h2">Roles &amp; Institutions</h2>
-    <ul>
-      {% for e in p.experience limit:4 %}
-        <li><strong>{{ e.role }}</strong> — {{ e.company }}</li>
-      {% endfor %}
-      {% for v in p.volunteer limit:2 %}
-        <li><strong>{{ v.role }}</strong> — {{ v.company }}</li>
-      {% endfor %}
-    </ul>
-    <p><a href="{{ '/experience/' | relative_url }}">More roles →</a></p>
+<section class="card">
+  <h2 class="h2">Development Environment</h2>
+  <div class="grid stats">
+    <div class="stat">
+      <h3 class="h1">{{ env.gpu_status }}</h3>
+      <p class="mono">GPU Status</p>
+    </div>
+    <div class="stat">
+      <h3 class="h1">{{ env.memory }}</h3>
+      <p class="mono">System RAM</p>
+    </div>
+    <div class="stat">
+      <h3 class="h1">{{ env.activity }}</h3>
+      <p class="mono">Last 24h</p>
+    </div>
+    <div class="stat">
+      <h3 class="h1">{{ env.training }}</h3>
+      <p class="mono">Current Project</p>
+    </div>
   </div>
+</section>
+
+<section class="card">
+  <h2 class="h2">Let's Connect</h2>
+  <p>Always up for a chat about scaling GenAI systems, LLM evaluation frameworks, production ML challenges, and the latest research.</p>
+  <div class="grid">
+    <div>
+      <h3>Professional</h3>
+      <p>Email: <a href="mailto:{{ p.email }}">{{ p.email }}</a></p>
+      <p>LinkedIn: <a href="{{ p.linkedin }}" target="_blank">{{ p.linkedin }}</a></p>
+    </div>
+    <div>
+      <h3>Development</h3>
+      <p>GitHub: <a href="{{ p.github }}" target="_blank">{{ p.github }}</a></p>
+      <p>Kaggle: <a href="{{ p.kaggle }}" target="_blank">{{ p.kaggle }}</a></p>
+    </div>
+  </div>
+</section>
+
+<div class="card">
+  <h2 class="h2">Highlights</h2>
+  <ul>
+    {% for h in p.highlights %}
+      <li>{{ h }}</li>
+    {% endfor %}
+  </ul>
+</div>
+
+<div class="card">
+  <h2 class="h2">Roles &amp; Institutions</h2>
+  <div class="grid role-grid">
+    {% for e in p.experience limit:4 %}
+      <div class="role-tile">
+        <div class="logo">{{ e.company | slice: 0,1 }}</div>
+        <div>
+          <p><strong>{{ e.role }}</strong></p>
+          <p class="mono">{{ e.company }}</p>
+        </div>
+      </div>
+    {% endfor %}
+    {% for v in p.volunteer limit:2 %}
+      <div class="role-tile">
+        <div class="logo">{{ v.company | slice: 0,1 }}</div>
+        <div>
+          <p><strong>{{ v.role }}</strong></p>
+          <p class="mono">{{ v.company }}</p>
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+  <p><a href="{{ '/experience/' | relative_url }}">More roles →</a></p>
+</div>
 
 <div class="card">
   <h2 class="h2">Publications</h2>
@@ -82,3 +146,4 @@ title: Home
   </ul>
   <p><a href="{{ '/blogs.html' | relative_url }}">More blogs →</a></p>
 </div>
+


### PR DESCRIPTION
## Summary
- Add Kaggle link to profile data
- Redesign index with hero social links, status tiles, environment stats, and role tiles
- Style new tiles and grids for interactive layout

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e806de808320831a3f85492db5ef