### PR TITLE
Remove resource graph and show real-time RAM/GPU stats

### DIFF
--- a/_data/development.yml
+++ b/_data/development.yml
@@ -1,5 +1,5 @@
-gpu_status: "--"
-memory: "--"
+gpu_util: "--"
+ram_util: "--"
 activity: "--"
 training: "--"
 blogs: "--"

--- a/index.html
+++ b/index.html
@@ -21,29 +21,28 @@ title: Home
 
 <section class="card">
   <h2 class="h2">Development Environment</h2>
-  <div class="grid stats">
-    <div class="stat">
-      <h3 class="h1" id="gpu-status">{{ env.gpu_status }}</h3>
-      <p class="mono">GPU Status</p>
+    <div class="grid stats">
+      <div class="stat">
+        <h3 class="h1" id="gpu-util">{{ env.gpu_util }}</h3>
+        <p class="mono">GPU Utilization</p>
+      </div>
+      <div class="stat">
+        <h3 class="h1" id="ram-util">{{ env.ram_util }}</h3>
+        <p class="mono">RAM Utilization</p>
+      </div>
+      <div class="stat">
+        <h3 class="h1" id="activity">{{ env.activity }}</h3>
+        <p class="mono">Last 24h</p>
+      </div>
+      <div class="stat">
+        <h3 class="h1" id="training">{{ env.training }}</h3>
+        <p class="mono">Current Project</p>
+      </div>
+      <div class="stat">
+        <h3 class="h1" id="blog-count">{{ env.blogs }}</h3>
+        <p class="mono">Blogs</p>
+      </div>
     </div>
-    <div class="stat">
-      <h3 class="h1" id="memory">{{ env.memory }}</h3>
-      <p class="mono">System RAM</p>
-    </div>
-    <div class="stat">
-      <h3 class="h1" id="activity">{{ env.activity }}</h3>
-      <p class="mono">Last 24h</p>
-    </div>
-    <div class="stat">
-      <h3 class="h1" id="training">{{ env.training }}</h3>
-      <p class="mono">Current Project</p>
-    </div>
-    <div class="stat">
-      <h3 class="h1" id="blog-count">{{ env.blogs }}</h3>
-      <p class="mono">Blogs</p>
-    </div>
-  </div>
-  <canvas id="resource-chart"></canvas>
 </section>
 
 <section class="card">

--- a/scripts/env_server.py
+++ b/scripts/env_server.py
@@ -6,7 +6,6 @@ import platform
 import psutil
 import shutil
 import subprocess
-from typing import List
 
 app = Flask(__name__)
 
@@ -71,37 +70,17 @@ def gpu_percent() -> float:
     return 0.0
 
 
-GPU_HISTORY: List[float] = []
-CPU_HISTORY: List[float] = []
-RAM_HISTORY: List[float] = []
-MAX_HISTORY = 20
-
-
 @app.get("/system/stats")
 def system_stats():
-    """Expose GPU status, available RAM and training progress with histories."""
+    """Expose real-time GPU and RAM utilization."""
 
     memory = psutil.virtual_memory()
-    cpu = psutil.cpu_percent()
-    ram = memory.percent
     gpu = gpu_percent()
 
-    for hist, value in (
-        (GPU_HISTORY, gpu),
-        (CPU_HISTORY, cpu),
-        (RAM_HISTORY, ram),
-    ):
-        hist.append(value)
-        if len(hist) > MAX_HISTORY:
-            hist.pop(0)
-
     data = {
-        "gpu_status": gpu_temperature(),
-        "memory": f"{memory.available / (1024 ** 3):.1f} GB",
+        "gpu_util": gpu,
+        "ram_util": memory.percent,
         "training": os.getenv("TRAINING_PROGRESS", "N/A"),
-        "gpu": GPU_HISTORY,
-        "cpu": CPU_HISTORY,
-        "ram": RAM_HISTORY,
     }
     return jsonify(data)
 


### PR DESCRIPTION
## Summary
- drop historical resource tracking and chart widget
- report real-time GPU and RAM utilization via the API
- display new utilization stats on the home page

## Testing
- `node --check assets/js/main.js`
- `python -m py_compile scripts/env_server.py`


------
https://chatgpt.com/codex/tasks/task_e_68a917c82a0c832082b6112c99dce695