### PR TITLE
Remove unused system tiles and update blog count

### DIFF
--- a/_data/development.yml
+++ b/_data/development.yml
@@ -1,5 +1,2 @@
-gpu_util: "--"
-ram_util: "--"
 activity: "--"
-training: "--"
-blogs: "--"
+blogs: "32"

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -60,10 +60,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   // Live development environment stats
-  const gpuEl = document.getElementById('gpu-util');
-  const ramEl = document.getElementById('ram-util');
   const activityEl = document.getElementById('activity');
-  const trainingEl = document.getElementById('training');
   const blogEl = document.getElementById('blog-count');
 
   const loadActivity = async () => {
@@ -87,48 +84,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   };
 
-  const pollSystemStats = async () => {
-    if (!gpuEl || !ramEl || !trainingEl) return;
-    try {
-      const res = await fetch('http://localhost:8001/system/stats');
-      if (!res.ok) throw new Error('network');
-      const data = await res.json();
-
-      if (typeof data.gpu_util === 'number') {
-        const gpuText = `${data.gpu_util.toFixed(0)}%`;
-        gpuEl.textContent = gpuText;
-        localStorage.setItem('gpu-util', gpuText);
-      } else {
-        const cached = localStorage.getItem('gpu-util');
-        if (cached) gpuEl.textContent = cached;
-      }
-
-      if (typeof data.ram_util === 'number') {
-        const ramText = `${data.ram_util.toFixed(0)}%`;
-        ramEl.textContent = ramText;
-        localStorage.setItem('ram-util', ramText);
-      } else {
-        const cached = localStorage.getItem('ram-util');
-        if (cached) ramEl.textContent = cached;
-      }
-
-      if (data.training) {
-        trainingEl.textContent = data.training;
-        localStorage.setItem('training', data.training);
-      } else {
-        const cached = localStorage.getItem('training');
-        if (cached) trainingEl.textContent = cached;
-      }
-    } catch (err) {
-      const gpuCached = localStorage.getItem('gpu-util');
-      gpuEl.textContent = gpuCached || '--';
-      const ramCached = localStorage.getItem('ram-util');
-      ramEl.textContent = ramCached || '--';
-      const tr = localStorage.getItem('training');
-      trainingEl.textContent = tr || '--';
-    }
-  };
-
   const loadBlogCount = async () => {
     if (!blogEl) return;
     try {
@@ -146,8 +101,6 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   loadActivity();
-  pollSystemStats();
   loadBlogCount();
-  setInterval(pollSystemStats, 5000);
 });
 

--- a/index.html
+++ b/index.html
@@ -23,20 +23,8 @@ title: Home
   <h2 class="h2">Development Environment</h2>
     <div class="grid stats">
       <div class="stat">
-        <h3 class="h1" id="gpu-util">{{ env.gpu_util }}</h3>
-        <p class="mono">GPU Utilization</p>
-      </div>
-      <div class="stat">
-        <h3 class="h1" id="ram-util">{{ env.ram_util }}</h3>
-        <p class="mono">RAM Utilization</p>
-      </div>
-      <div class="stat">
         <h3 class="h1" id="activity">{{ env.activity }}</h3>
         <p class="mono">Last 24h</p>
-      </div>
-      <div class="stat">
-        <h3 class="h1" id="training">{{ env.training }}</h3>
-        <p class="mono">Current Project</p>
       </div>
       <div class="stat">
         <h3 class="h1" id="blog-count">{{ env.blogs }}</h3>


### PR DESCRIPTION
## Summary
- Drop GPU utilization, RAM utilization, and current project tiles from the home page.
- Simplify front-end script to only update recent activity and blog count.
- Record 32 published blogs in development data.

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: tunnel error during installation)*

------
https://chatgpt.com/codex/tasks/task_e_68a91a6892648320ac1d59ee525c6ed9