### PR TITLE
feat: refresh live stats periodically

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -135,5 +135,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   loadCommitStats();
   loadBlogCount();
+
+  // Refresh stats periodically to keep figures up to date
+  setInterval(loadCommitStats, 5 * 60 * 1000);
+  setInterval(loadBlogCount, 60 * 60 * 1000);
 });
 


### PR DESCRIPTION
## Summary
- refresh commit stats every 5 minutes and blog count hourly to keep displayed numbers current

## Testing
- `node --check assets/js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68a91e9946008320a86f6cd2dbb30ada