### PR TITLE
Rename Development Environment heading to Recent Activity

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -59,7 +59,7 @@ document.addEventListener('DOMContentLoaded', () => {
     observer.observe(card);
   });
 
-  // Live development environment stats
+  // Live recent activity stats
   const commitCountEl = document.getElementById('commit-count');
   const commitLabelEl = document.getElementById('commit-label');
   const blogEl = document.getElementById('blog-count');

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@ title: Home
 </section>
 
 <section class="card">
-  <h2 class="h2">Development Environment</h2>
+  <h2 class="h2">Recent Activity</h2>
     <div class="grid stats">
       <div class="stat">
         <h3 class="h1" id="commit-count">{{ env.activity }}</h3>


### PR DESCRIPTION
## Summary
- rename "Development Environment" section on home page to "Recent Activity"
- update related comment in main.js

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a78aee9c8320990290d15215d18a