### PR TITLE
Enhance layout with theme colors and accessible focus

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,12 +8,14 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <meta name="theme-color" content="#f9fafb" media="(prefers-color-scheme: light)">
+    <meta name="theme-color" content="#111827" media="(prefers-color-scheme: dark)">
     <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
   </head>
   <body>
     <header class="site-header">
       <a class="brand" href="{{ '/' | relative_url }}">{{ site.title }}</a>
-      <button id="nav-toggle" class="menu-toggle" aria-label="Toggle navigation">☰</button>
+      <button id="nav-toggle" class="menu-toggle" aria-label="Toggle navigation" aria-controls="site-nav" aria-expanded="false">☰</button>
       <nav id="site-nav">
         <a href="{{ '/' | relative_url }}">Home</a>
         <a href="{{ '/experience/' | relative_url }}">Experience</a>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -20,6 +20,10 @@
   --badge-bg: #1f2937;
 }
 
+html {
+  color-scheme: light dark;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -37,6 +41,12 @@ body {
 a {
   color: var(--accent);
   text-decoration: none;
+}
+
+a:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .container {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -26,6 +26,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const siteNav = document.getElementById('site-nav');
   if (navToggle && siteNav) {
     navToggle.addEventListener('click', () => {
+      const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+      navToggle.setAttribute('aria-expanded', String(!expanded));
       siteNav.classList.toggle('open');
     });
   }


### PR DESCRIPTION
## Summary
- add theme-color meta tags and ARIA data to default layout
- style :focus-visible outlines and declare color-scheme
- toggle nav button `aria-expanded` for accessibility

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68a9a9b3b4048320a4dec5688e14b857