### PR TITLE
Add volunteer history with logos

### DIFF
--- a/_data/profile.yml
+++ b/_data/profile.yml
@@ -125,15 +125,37 @@ education:
   program: B.Tech, Computer Science and Engineering
   date: "2016 \u2013 2020"
 volunteer:
-- company: Data Science for All
+- company: OpenSource Connections
   role: Mentor
-  date: "2022 \u2013 Present"
-  location: Remote
-  bullets:
-  - Support aspiring data scientists through project mentorship.
-- company: Local Community Hackathon
-  role: Volunteer
-  date: "2021 \u2013 2022"
-  location: Toronto, ON
-  bullets:
-  - Organized AI workshops for community participants.
+  date: "Apr 2025 \u2013 Present"
+  logo: https://avatars.githubusercontent.com/u/1776596?v=4
+  bullets: []
+- company: Map the System Canada
+  role: Mentor
+  date: "Feb 2025 \u2013 Present"
+  logo: https://avatars.githubusercontent.com/u/63322516?v=4
+  bullets: []
+- company: Kaggle
+  role: Advisor
+  date: "Aug 2024 \u2013 Feb 2025"
+  logo: https://avatars.githubusercontent.com/u/1336944?v=4
+  bullets: []
+- company: Sikheya Institute
+  role: "Artificial Intelligence \u2013 Domain Guide"
+  date: "Aug 2024 \u2013 Apr 2025"
+  bullets: []
+- company: Humber International Graduate School (IGS)
+  role: Data Analytics Mentor
+  date: "Jan 2024 \u2013 Mar 2025"
+  logo: https://avatars.githubusercontent.com/u/25174995?v=4
+  bullets: []
+- company: Sabudh Foundation
+  role: Senior Mentor
+  date: "Jan 2023 \u2013 Aug 2023"
+  logo: https://avatars.githubusercontent.com/u/129847691?v=4
+  bullets: []
+- company: Sabudh Foundation
+  role: Mentor
+  date: "Jul 2020 \u2013 Jan 2023"
+  logo: https://avatars.githubusercontent.com/u/129847691?v=4
+  bullets: []

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -282,6 +282,19 @@ kbd {
   border: 1px solid var(--border);
 }
 
+/* Volunteer logos */
+.volunteer-header {
+  display: flex;
+  align-items: center;
+}
+
+.volunteer-logo {
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+  margin-right: 12px;
+}
+
 /* Mobile navigation */
 .menu-toggle {
   display: none;

--- a/volunteer.md
+++ b/volunteer.md
@@ -10,10 +10,15 @@ permalink: /volunteer/
 
 {% for v in p.volunteer %}
 <div class="card">
-  <h3 class="h2">{{ v.role }} — {{ v.company }}</h3>
+  <div class="volunteer-header">
+    {% if v.logo %}<img src="{{ v.logo }}" alt="{{ v.company }} logo" class="volunteer-logo">{% endif %}
+    <h3 class="h2">{{ v.role }} — {{ v.company }}</h3>
+  </div>
   <p class="mono">{{ v.date }}{% if v.location %} · {{ v.location }}{% endif %}</p>
+  {% if v.bullets and v.bullets != empty %}
   <ul>
   {% for b in v.bullets %}<li>{{ b }}</li>{% endfor %}
   </ul>
+  {% endif %}
 </div>
 {% endfor %}


### PR DESCRIPTION
## Summary
- replace local logo images with remote avatar URLs to avoid binary assets
- update volunteer profile entries to point to external logos

## Testing
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68a9ab1855188320a1d36084f8178a28