### PR TITLE
Improve dark mode and add syntax highlighting

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,6 +11,8 @@
     <meta name="theme-color" content="#f9fafb" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#111827" media="(prefers-color-scheme: dark)">
     <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" media="(prefers-color-scheme: dark)">
   </head>
   <body>
     <header class="site-header">
@@ -32,6 +34,7 @@
     <footer class="site-footer">
       <p>© {{ "now" | date: "%Y" }} {{ site.title }}</p>
     </footer>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
     <script src="{{ '/assets/js/main.js' | relative_url }}"></script>
   </body>
 </html>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -7,6 +7,7 @@
   --accent-gradient: linear-gradient(135deg, #ff5722, #ff9800);
   --border: #e5e7eb;
   --badge-bg: #f3f4f6;
+  --code-bg: #f3f4f6;
 }
 
 .dark {
@@ -18,6 +19,7 @@
   --accent-gradient: linear-gradient(135deg, #ff5722, #ff9800);
   --border: #374151;
   --badge-bg: #1f2937;
+  --code-bg: #1f2937;
 }
 
 html {
@@ -139,6 +141,21 @@ nav a:hover::after {
 }
 
 .mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+}
+
+pre {
+  background: var(--code-bg);
+  padding: 16px;
+  border-radius: 8px;
+  overflow-x: auto;
+}
+
+pre code {
+  display: block;
+}
+
+code {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -141,5 +141,10 @@ document.addEventListener('DOMContentLoaded', () => {
   // Refresh stats periodically to keep figures up to date
   setInterval(loadCommitStats, 5 * 60 * 1000);
   setInterval(loadBlogCount, 60 * 60 * 1000);
+
+  // Syntax highlighting
+  if (window.hljs) {
+    hljs.highlightAll();
+  }
 });
 


### PR DESCRIPTION
## Summary
- add code background variables and base styles for readable code blocks in light and dark modes
- include highlight.js GitHub themes and script for color-coded syntax highlighting
- initialize syntax highlighter on page load

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c11e405c8320be9453110471710e